### PR TITLE
Dockerfile for reproduction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip ffmpeg libsm6 libxext6 && \
+    pip3 install --upgrade pip setuptools
+
+WORKDIR /logo-detection
+
+COPY . /logo-detection
+
+RUN pip3 install -r requirements.txt


### PR DESCRIPTION
I encountered a few difficulties trying to run this due to outdated packages in the requirements conflicting with my current Python installation.

Therefore, having something like a Dockerfile, which I propose here, or a Nix flake would be helpful for others trying to test this.

This setup only uses the CPU, which was sufficient for my testing purposes. Since this repository appears to be inactive, I won't spend more time on it. However, it would be beneficial if someone could build on this to enable GPU usage in Docker.